### PR TITLE
protect against broken tar file from bintray

### DIFF
--- a/.github/workflows/run_fuzzer.yml
+++ b/.github/workflows/run_fuzzer.yml
@@ -29,7 +29,7 @@ jobs:
       working-directory: fuzzing/
       run: |
         echo uploading each artifact twice, otherwise it will not be published
-        tar cf - cmin > corpus.tar
+        tar cf - cmin > corpus.tar.tmp && mv corpus.tar.tmp corpus.tar
         curl -T corpus.tar -u$BINTRAYUSER:${{ secrets.bintrayApiKey }} https://api.bintray.com/content/$BINTRAYORG/boost.json/corpus/0/corpus.tar";publish=1;override=1"
         curl -T corpus.tar -u$BINTRAYUSER:${{ secrets.bintrayApiKey }} https://api.bintray.com/content/$BINTRAYORG/boost.json/corpus/0/corpus.tar";publish=1;override=1"
     - name: Save the corpus as a github artifact

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -73,7 +73,7 @@ fi
 # get it with curl -O --location -J https://bintray.com/pauldreik/boost.json/download_file?file_path=corpus%2Fcorpus.tar
 if [ -e corpus.tar ] ; then
   mkdir -p oldcorpus
-  tar xf corpus.tar -C oldcorpus
+  tar xf corpus.tar -C oldcorpus || echo "corpus.tar was broken! ignoring it"
   OLDCORPUS=oldcorpus/cmin/$variant
   # in case the old corpus did not have this variant (when adding/renaming a new fuzzer)
   mkdir -p $OLDCORPUS


### PR DESCRIPTION
The tar file on bintray is broken for some reason, perhaps due to an interrupted github action.

This tries to make the fuzzing script more robust against that, so the corpus is rebuilt again.

 - create the tar file under a temporary name locally, before moving it to the proper name
 - in case the tar file is bad when unpacked, proceed anyway