### PR TITLE
Pass total string size to handlers

### DIFF
--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -393,10 +393,10 @@ class boost_null_impl : public any_impl
             bool on_object_end(std::size_t, error_code&) { return true; }
             bool on_array_begin(error_code&) { return true; }
             bool on_array_end(std::size_t, error_code&) { return true; }
-            bool on_key_part(string_view, error_code&) { return true; }
-            bool on_key( string_view, error_code&) { return true; }
-            bool on_string_part(string_view, error_code&) { return true; }
-            bool on_string(string_view, error_code&) { return true; }
+            bool on_key_part(string_view, std::size_t, error_code&) { return true; }
+            bool on_key( string_view, std::size_t, error_code&) { return true; }
+            bool on_string_part(string_view, std::size_t, error_code&) { return true; }
+            bool on_string(string_view, std::size_t, error_code&) { return true; }
             bool on_number_part(string_view, error_code&) { return true; }
             bool on_int64(std::int64_t, string_view, error_code&) { return true; }
             bool on_uint64(std::uint64_t, string_view, error_code&) { return true; }

--- a/example/validate.cpp
+++ b/example/validate.cpp
@@ -41,10 +41,10 @@ validate( string_view s )
             bool on_object_end( std::size_t, error_code& ) { return true; }
             bool on_array_begin( error_code& ) { return true; }
             bool on_array_end( std::size_t, error_code& ) { return true; }
-            bool on_key_part( string_view, error_code& ) { return true; }
-            bool on_key( string_view, error_code& ) { return true; }
-            bool on_string_part( string_view, error_code& ) { return true; }
-            bool on_string( string_view, error_code& ) { return true; }
+            bool on_key_part( string_view, std::size_t, error_code& ) { return true; }
+            bool on_key( string_view, std::size_t, error_code& ) { return true; }
+            bool on_string_part( string_view, std::size_t, error_code& ) { return true; }
+            bool on_string( string_view, std::size_t, error_code& ) { return true; }
             bool on_number_part( string_view, error_code& ) { return true; }
             bool on_int64( std::int64_t, string_view, error_code& ) { return true; }
             bool on_uint64( std::uint64_t, string_view, error_code& ) { return true; }

--- a/fuzzing/fuzz_basic_parser.cpp
+++ b/fuzzing/fuzz_basic_parser.cpp
@@ -30,10 +30,10 @@ validate( string_view s )
             bool on_object_end( std::size_t, error_code& ) { return true; }
             bool on_array_begin( error_code& ) { return true; }
             bool on_array_end( std::size_t, error_code& ) { return true; }
-            bool on_key_part( string_view, error_code& ) { return true; }
-            bool on_key( string_view, error_code& ) { return true; }
-            bool on_string_part( string_view, error_code& ) { return true; }
-            bool on_string( string_view, error_code& ) { return true; }
+            bool on_key_part( string_view, std::size_t, error_code& ) { return true; }
+            bool on_key( string_view, std::size_t, error_code& ) { return true; }
+            bool on_string_part( string_view, std::size_t, error_code& ) { return true; }
+            bool on_string( string_view, std::size_t, error_code& ) { return true; }
             bool on_number_part( string_view, error_code& ) { return true; }
             bool on_int64( std::int64_t, string_view, error_code& ) { return true; }
             bool on_uint64( std::uint64_t, string_view, error_code& ) { return true; }

--- a/include/boost/json/basic_parser.hpp
+++ b/include/boost/json/basic_parser.hpp
@@ -978,7 +978,7 @@ parse_unescaped(const char* p)
         if(BOOST_JSON_LIKELY(size))
         {
             if(BOOST_JSON_UNLIKELY(! (h_.*on_part)(
-                {start, size}, ec_)))
+                {start, size}, total, ec_)))
                 return fail(cs.begin());
         }
         return maybe_suspend(cs.begin(), state::str1, total);
@@ -994,7 +994,7 @@ parse_unescaped(const char* p)
             if(BOOST_JSON_LIKELY(size))
             {
                 if(BOOST_JSON_UNLIKELY(! (h_.*on_part)(
-                    {start, size}, ec_)))
+                    {start, size}, total, ec_)))
                     return fail(cs.begin());
             }
             return maybe_suspend(cs.end(), state::str8, total);
@@ -1005,7 +1005,7 @@ parse_unescaped(const char* p)
             if(BOOST_JSON_LIKELY(size))
             {
                 if(BOOST_JSON_UNLIKELY(! (h_.*on_part)(
-                    {start, size}, ec_)))
+                    {start, size}, total, ec_)))
                     return fail(cs.begin());
             }
             return parse_escaped<StackEmpty, IsKey,
@@ -1015,7 +1015,7 @@ parse_unescaped(const char* p)
         return fail(cs.begin(), error::syntax);
     }
     if(BOOST_JSON_UNLIKELY(! (h_.*on_full)(
-        {start, size}, ec_)))
+        {start, size}, total, ec_)))
         return fail(cs.begin());
     ++cs;
     return cs.begin();
@@ -1096,7 +1096,7 @@ do_str3:
                 return fail(cs.begin(), ev_too_large);
             total += temp.size();
             if(BOOST_JSON_UNLIKELY(
-                ! (h_.*on_part)(temp, ec_)))
+                ! (h_.*on_part)(temp, total, ec_)))
                 return fail(cs.begin());
             temp.clear();
         }
@@ -1245,7 +1245,7 @@ do_str3:
                 return fail(cs.begin(), ev_too_large);
             total += temp.size();
             if(BOOST_JSON_UNLIKELY(
-                ! (h_.*on_part)(temp, ec_)))
+                ! (h_.*on_part)(temp, total, ec_)))
                 return fail(cs.begin());
             temp.clear();
             cs.clip(temp.max_size());
@@ -1374,7 +1374,7 @@ do_str2:
                     return fail(cs.begin(), ev_too_large);
                 total += temp.size();
                 if(BOOST_JSON_UNLIKELY(
-                    ! (h_.*on_part)(temp, ec_)))
+                    ! (h_.*on_part)(temp, total, ec_)))
                     return fail(cs.begin());
                 temp.clear();
             }
@@ -1390,7 +1390,7 @@ do_str2:
                 return fail(cs.begin(), ev_too_large);
             total += temp.size();
             if(BOOST_JSON_UNLIKELY(
-                ! (h_.*on_full)(temp, ec_)))
+                ! (h_.*on_full)(temp, total, ec_)))
                 return fail(cs.begin());
             ++cs;
             return cs.begin();
@@ -1407,7 +1407,7 @@ do_str2:
                         return fail(cs.begin(), ev_too_large);
                     total += temp.size();
                     if(BOOST_JSON_UNLIKELY(
-                        ! (h_.*on_part)(temp, ec_)))
+                        ! (h_.*on_part)(temp, total, ec_)))
                         return fail(cs.begin());
                     temp.clear();
                 }

--- a/include/boost/json/detail/basic_parser.hpp
+++ b/include/boost/json/detail/basic_parser.hpp
@@ -114,10 +114,10 @@ BOOST_JSON_NS_BEGIN
         /// Called when the end of the current object is encountered.
         ///
         /// @return `true` on success.
-        /// @param size The number of elements in the object.
+        /// @param n The number of elements in the object.
         /// @param ec Set to the error, if any occurred.
         ///
-        bool on_object_end( std::size_t size, error_code& ec );
+        bool on_object_end( std::size_t n, error_code& ec );
 
         /// Called when the beginning of an array is encountered.
         ///
@@ -129,10 +129,10 @@ BOOST_JSON_NS_BEGIN
         /// Called when the end of the current array is encountered.
         ///
         /// @return `true` on success.
-        /// @param size The number of elements in the array.
+        /// @param n The number of elements in the array.
         /// @param ec Set to the error, if any occurred.
         ///
-        bool on_array_end( error_code& ec );
+        bool on_array_end( std::size_t n, error_code& ec );
 
         /// Called with characters corresponding to part of the current key.
         ///

--- a/include/boost/json/detail/basic_parser.hpp
+++ b/include/boost/json/detail/basic_parser.hpp
@@ -138,33 +138,37 @@ BOOST_JSON_NS_BEGIN
         ///
         /// @return `true` on success.
         /// @param s The partial characters
+        /// @param n The total size of the key thus far
         /// @param ec Set to the error, if any occurred.
         ///
-        bool on_key_part( string_view s, error_code& ec );
+        bool on_key_part( string_view s, std::size_t n, error_code& ec );
 
         /// Called with the last characters corresponding to the current key.
         ///
         /// @return `true` on success.
         /// @param s The remaining characters
+        /// @param n The total size of the key
         /// @param ec Set to the error, if any occurred.
         ///
-        bool on_key( string_view s, error_code& ec );
+        bool on_key( string_view s, std::size_t n, error_code& ec );
 
         /// Called with characters corresponding to part of the current string.
         ///
         /// @return `true` on success.
         /// @param s The partial characters
+        /// @param n The total size of the string thus far
         /// @param ec Set to the error, if any occurred.
         ///
-        bool on_string_part( string_view s, error_code& ec );
+        bool on_string_part( string_view s, std::size_t n, error_code& ec );
 
         /// Called with the last characters corresponding to the current string.
         ///
         /// @return `true` on success.
         /// @param s The remaining characters
+        /// @param n The total size of the string
         /// @param ec Set to the error, if any occurred.
         ///
-        bool on_string( string_view s, error_code& ec );
+        bool on_string( string_view s, std::size_t n, error_code& ec );
 
         /// Called with the characters corresponding to part of the current number.
         ///

--- a/include/boost/json/impl/parser.ipp
+++ b/include/boost/json/impl/parser.ipp
@@ -82,6 +82,7 @@ parser::
 handler::
 on_key_part(
     string_view s,
+    std::size_t,
     error_code&)
 {
     st.push_chars(s);
@@ -93,6 +94,7 @@ parser::
 handler::
 on_key(
     string_view s,
+    std::size_t,
     error_code&)
 {
     st.push_key(s);
@@ -104,6 +106,7 @@ parser::
 handler::
 on_string_part(
     string_view s,
+    std::size_t, 
     error_code&)
 {
     st.push_chars(s);
@@ -115,6 +118,7 @@ parser::
 handler::
 on_string(
     string_view s,
+    std::size_t, 
     error_code&)
 {
     st.push_string(s);

--- a/include/boost/json/parser.hpp
+++ b/include/boost/json/parser.hpp
@@ -115,10 +115,10 @@ class parser
         inline bool on_object_end(std::size_t n, error_code& ec);
         inline bool on_array_begin(error_code& ec);
         inline bool on_array_end(std::size_t n, error_code& ec);
-        inline bool on_key_part(string_view s, error_code& ec);
-        inline bool on_key(string_view s, error_code& ec);
-        inline bool on_string_part(string_view s, error_code& ec);
-        inline bool on_string(string_view s, error_code& ec);
+        inline bool on_key_part(string_view s, std::size_t n, error_code& ec);
+        inline bool on_key(string_view s, std::size_t n, error_code& ec);
+        inline bool on_string_part(string_view s, std::size_t n, error_code& ec);
+        inline bool on_string(string_view s, std::size_t n, error_code& ec);
         inline bool on_number_part(string_view, error_code&);
         inline bool on_int64(std::int64_t i, string_view, error_code& ec);
         inline bool on_uint64(std::uint64_t u, string_view, error_code& ec);

--- a/test/basic_parser.cpp
+++ b/test/basic_parser.cpp
@@ -911,10 +911,10 @@ public:
                     bool on_object_end( std::size_t, error_code& ) { return true; }
                     bool on_array_begin( error_code& ) { return true; }
                     bool on_array_end( std::size_t, error_code& ) { return true; }
-                    bool on_key_part( string_view, error_code& ) { return true; }
-                    bool on_key( string_view, error_code& ) { return true; }
-                    bool on_string_part( string_view, error_code& ) { return true; }
-                    bool on_string( string_view, error_code& ) { return true; }
+                    bool on_key_part( string_view, std::size_t, error_code& ) { return true; }
+                    bool on_key( string_view, std::size_t, error_code& ) { return true; }
+                    bool on_string_part( string_view, std::size_t, error_code& ) { return true; }
+                    bool on_string( string_view, std::size_t, error_code& ) { return true; }
                     bool on_number_part( string_view, error_code&) { return true; }
                     bool on_int64( std::int64_t, string_view, error_code& ) { return true; }
                     bool on_uint64( std::uint64_t, string_view, error_code& ) { return true; }
@@ -1240,14 +1240,14 @@ public:
                 bool on_object_end( std::size_t, error_code& ) { return true; }
                 bool on_array_begin( error_code& ) { return true; }
                 bool on_array_end( std::size_t, error_code& ) { return true; }
-                bool on_key_part( string_view, error_code& ) { return true; }
-                bool on_key( string_view, error_code& ) { return true; }
-                bool on_string_part( string_view sv, error_code& )
+                bool on_key_part( string_view, std::size_t, error_code& ) { return true; }
+                bool on_key( string_view, std::size_t, error_code& ) { return true; }
+                bool on_string_part( string_view sv, std::size_t, error_code& )
                 {
                     captured.append(sv.data(), sv.size());
                     return true;
                 }
-                bool on_string( string_view sv, error_code& )
+                bool on_string( string_view sv, std::size_t, error_code& )
                 {
                     captured.append(sv.data(), sv.size());
                     return true;
@@ -1376,10 +1376,10 @@ public:
                 bool on_object_end( std::size_t, error_code& ) { return true; }
                 bool on_array_begin( error_code& ) { return true; }
                 bool on_array_end( std::size_t, error_code& ) { return true; }
-                bool on_key_part( string_view, error_code& ) { return true; }
-                bool on_key( string_view, error_code& ) { return true; }
-                bool on_string_part( string_view, error_code& ) { return true; }
-                bool on_string( string_view, error_code& ) { return true; }
+                bool on_key_part( string_view, std::size_t, error_code& ) { return true; }
+                bool on_key( string_view, std::size_t, error_code& ) { return true; }
+                bool on_string_part( string_view, std::size_t, error_code& ) { return true; }
+                bool on_string( string_view, std::size_t, error_code& ) { return true; }
                 bool on_number_part( string_view sv, error_code&) 
                 { 
                     captured.append(sv.data(), sv.size());

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -151,10 +151,10 @@ class null_parser
         bool on_object_end( std::size_t, error_code& ) { return true; }
         bool on_array_begin( error_code& ) { return true; }
         bool on_array_end( std::size_t, error_code& ) { return true; }
-        bool on_key_part( string_view, error_code& ) { return true; }
-        bool on_key( string_view, error_code& ) { return true; }
-        bool on_string_part( string_view, error_code& ) { return true; }
-        bool on_string( string_view, error_code& ) { return true; }
+        bool on_key_part( string_view, std::size_t, error_code& ) { return true; }
+        bool on_key( string_view, std::size_t, error_code& ) { return true; }
+        bool on_string_part( string_view, std::size_t, error_code& ) { return true; }
+        bool on_string( string_view, std::size_t, error_code& ) { return true; }
         bool on_number_part( string_view, error_code&) { return true; }
         bool on_int64( std::int64_t, string_view, error_code& ) { return true; }
         bool on_uint64( std::uint64_t, string_view, error_code& ) { return true; }
@@ -268,6 +268,7 @@ class fail_parser
         bool
         on_key_part(
             string_view,
+            std::size_t, 
             error_code& ec)
         {
             return maybe_fail(ec);
@@ -276,6 +277,7 @@ class fail_parser
         bool
         on_key(
             string_view,
+            std::size_t, 
             error_code& ec)
         {
             return maybe_fail(ec);
@@ -284,6 +286,7 @@ class fail_parser
         bool
         on_string_part(
             string_view,
+            std::size_t, 
             error_code& ec)
         {
             return maybe_fail(ec);
@@ -292,6 +295,7 @@ class fail_parser
         bool
         on_string(
             string_view,
+            std::size_t, 
             error_code& ec)
         {
             return maybe_fail(ec);
@@ -503,6 +507,7 @@ class throw_parser
         bool
         on_key_part(
             string_view,
+            std::size_t, 
             error_code&)
         {
             return maybe_throw();
@@ -511,6 +516,7 @@ class throw_parser
         bool
         on_key(
             string_view,
+            std::size_t, 
             error_code&)
         {
             return maybe_throw();
@@ -519,6 +525,7 @@ class throw_parser
         bool
         on_string_part(
             string_view,
+            std::size_t, 
             error_code&)
         {
             return maybe_throw();
@@ -527,6 +534,7 @@ class throw_parser
         bool
         on_string(
             string_view,
+            std::size_t, 
             error_code&)
         {
             return maybe_throw();


### PR DESCRIPTION
fix #266

This only passes the total string size to the handlers, the parameter isn't actually used anywhere.