### PR TITLE
Remove unnecessary `reset()` in example

### DIFF
--- a/example/pretty.cpp
+++ b/example/pretty.cpp
@@ -28,7 +28,6 @@ parse_file( char const* filename )
     file f( filename, "r" );
     json::parser p;
     json::error_code ec;
-    p.reset();
     do
     {
         char buf[4096];


### PR DESCRIPTION
The call to `parser::reset` just after default construction is, as I understand, redundant.