### PR TITLE
fuzz different memory allocation strategies

### DIFF
--- a/fuzzing/.gitignore
+++ b/fuzzing/.gitignore
@@ -6,4 +6,6 @@ corpus.tar
 fuzzer_basic_parser
 fuzzer_parse
 fuzzer_parser
+out*/
+fuzz-*.log
 


### PR DESCRIPTION
This sets the BOOST_JSON_STACK_BUFFER_SIZE macro so interesting behaviour happens also for small inputs.

Otherwise bugs may go undetected because fuzzing in general wants small inputs and may never reach an interesting size in a reasonable time.

It also tries different memory handling strategies, as proposed by Vinnie on slack. 

I ran this for a few hours locally and it did not find anything on the current develop branch.

Closes #333 